### PR TITLE
Update openjdk and push weekly a rebuild on dockerhub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,8 @@
 name: Docker Image CI
 
 on:
+  schedule:
+    - cron: '0 8 * * 1'
   push:
     branches: [ "master" ]
   pull_request:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,6 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build the Docker image
-      run: docker build . --tag jelastic-cli:latest
+      run: docker build . --tag ${{ secrets.DOCKERHUB_USERNAME }}/jelastic-cli:latest
     - name: Push the Docker image
       run: docker push  ${{ secrets.DOCKERHUB_USERNAME }}/jelastic-cli:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,22 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build the Docker image
+      run: docker build . --tag jelastic-cli:latest
+    - name: Push the Docker image
+      run: docker push  ${{ secrets.DOCKERHUB_USERNAME }}/jelastic-cli:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:19-jdk-alpine
+ENV ROOT="/root/jelastic"
 
 RUN apk add --update curl wget bash && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Hello!
We have been using your image for years, and it served us so well… thanks a lot. 

We notice today we need to install some JPS on jelastic, but the `jelastic-cli` is not updated with the `marketplace` endpoints. 

Thus, in this PR you will find:

- a github action to push every monday morning an updated version of the `jelastic-cli`
- a bump of the openjdk version used

Thanks!